### PR TITLE
Hotfix charmspawning (#8)

### DIFF
--- a/DistantGreensCharms.cs
+++ b/DistantGreensCharms.cs
@@ -165,7 +165,7 @@ namespace DistantGreensCharms
             bool isRandomized = false;
             if (ModHooks.GetMod("MenuChanger") != null && ModHooks.GetMod("Randomizer 4") != null)
             {
-                isRandomized = RandomizerConnectionMenu.Instance.AddCharms;
+                isRandomized = RandomizerConnectionMenu.Instance.AddCharms && RandomizerMod.RandomizerMod.RS?.GenerationSettings != null;
             }
             
             if (isRandomized)


### PR DESCRIPTION
* Added ItemChanger and SFCore Dependencies

# Conflicts:
#	DistantGreensCharms.csproj

* MossMask Charm Behaviour

* SFCore and ItemChanger Modhooks still missing

* First draft of HUD Integration

* Fixed MossMask Charm functionality

* Charm Notch Cost Added, NEEEDS reworking

* HUD first draft - SHOWING SOMETHING!

* Basic Moss Mask Implementation working with HUD needs cleanup BADLY

* HUDElement Reworks and Restructuring

* Changed MossMask Textures

* Works, but race condition issues need to be adressed!

* Fixed Animations!!!

* Icon disappears after Mask breaks

* Godhome implementation

* Basic Randomizer Implementation Errors:
No Image displayed on Item Collect
No Location added
Unsure if NotchRandomizing works

* Fixed Randomizer, IT WAS 2 LINES

* Centralized Randomizer Hook Order

* DebugMod Integration & Created Integrations Folder

* Fixed CharmCost Randomization

* Added Item & LocationTags

* Cleanup in DistantGreensCharms.cs

* Jonis Fix

* Enabled Custom Parent, but still no idea on how to get it to render AFTER actual HUD

* Removed unessecary HUD UI Loaded Check

* README UPDATES!!!

* README MENTIONED IN CSPROJ :O

* Updated Dependencies

* Update ReadMe.adoc

* Painter Spirit Prototype

* Improved Upon Painters Spirit, still not on Nail Art

* Painters Spirit full functionality might change NailArts animations in the future aswell

* Location for MossMask

* Addec Locaiton for randomizer compat

* Linux Compat in csproj

* Fixed ItemChanger and changed Painters_Spirit location

* Fixed RandomizedCharmNotchCosts bug

* updated Readme and Spoilers

* Fixed RandomizerBug on disable charms

* hotfix, for charm spawning i ducking forgot to push this commit omg